### PR TITLE
利用可能なスペースに合わせてframe_boardのスケーリングを実装した

### DIFF
--- a/src/board/board.py
+++ b/src/board/board.py
@@ -57,16 +57,30 @@ class BoardOutputToGUI(BoardOutput):
     def __init__(self, first_color: str, second_color:str, gui_game_design: GUIGameDesign):
         self.first_color = first_color
         self.second_color = second_color
-        self.canvases = gui_game_design.canvases
-        self.cell_size = gui_game_design.cell_size
+
+        self._gui_game_design = gui_game_design
+
+    @property
+    def canvases(self):
+        return self._gui_game_design.canvases
+
+    @property
+    def cell_size(self) -> float:
+        return self._gui_game_design.cell_size
+
+    @property
+    def _stone_margin(self) -> float:
+        return self._gui_game_design.stone_margin
 
     def draw_stone(self, x, y, color):
         c = self.canvases[x][y]
-        margin = 5
+        margin = self._stone_margin
+       
         c.create_oval(
             margin, margin, 
             self.cell_size-margin, self.cell_size-margin,
-            fill=color
+            fill=color,
+            tags="stone"
         )
     
     def output_board(self, board: Board):

--- a/src/design/game_design.py
+++ b/src/design/game_design.py
@@ -14,10 +14,39 @@ class GUIGameDesign:
 
         # 盤面作成
         self.frame_board = tk.Frame(self.root)
-        self.frame_board.pack(side="bottom")
+        self.frame_board.pack(side="bottom", fill="both", expand=True)
+        self.frame_board.bind("<Configure>", self._on_frame_board_configure)
+
         self.canvases = [[None]*8 for _ in range(8)]
-        self.cell_size = 50
+
+        self._cell_size: float = 50.0
+        self._stone_margin: float = 5.0
+
         self._create_board_ui()
+
+    @property
+    def cell_size(self) -> float:
+        return self._cell_size
+
+    @property
+    def stone_margin(self) -> float:
+        return self._stone_margin
+
+    def _on_frame_board_configure(self, event):
+        """「frame_boardの<Configure>」イベントでキャンバスをスケーリングする。"""
+
+        if event.widget is not self.frame_board:
+            return
+
+        prev_cell_size = self._cell_size
+        self._cell_size = min(event.width, event.height) / 8
+        scale_ratio = self._cell_size / prev_cell_size
+        self._stone_margin *= scale_ratio
+
+        for row in self.canvases:
+            for cell_canvas in row:
+                cell_canvas.config(width=self._cell_size, height=self._cell_size)
+                cell_canvas.scale("stone", 0, 0, scale_ratio, scale_ratio)
     
     def _create_board_ui(self):
         for x in range(8):


### PR DESCRIPTION
こんにちは。
日本語で書かれた、小さくて理解しやすいリポジトリを探していました。
作業しながら学びたいと思っており、現在の日本語レベルは N5 前後です。

少し前にこちらのリポジトリを見つけました。
コードを実行してみたところ、このゲームがとても面白く、素晴らしいと思いました。

今回の Pull Request についてですが、私はタイル型ウィンドウマネージャを使用しており、
ウィンドウサイズが自動的に変更されます。
その際、frame_board がリサイズされない問題に気づいたため、部分的に修正しました。

現在は、ウィンドウサイズに合わせて frame_board がリサイズされるようになっています。
ただし、利用可能なスペースの中央に揃わない問題は、今回は対応していません。

私は Python を約 4 年間書いておらず、Tkinter もほとんど使ったことがありません。
そのため、tk のレイアウトシステムを改めて深く理解する必要がありました。
もしよろしければ、今後この中央揃えの問題や、他の問題の修正、または改善にも取り組むことができます。

動作確認は Python 3.13 / Windows 11 で行いました。
テストについては、from src.othello という import が正しくないため、今回は実行していません。

このメッセージは GPT の助けを借りて書いています。
不自然な表現や誤りがありましたら、申し訳ありません。